### PR TITLE
Add file-level size details

### DIFF
--- a/scripts/did_finder.py
+++ b/scripts/did_finder.py
@@ -141,7 +141,10 @@ def post_status_update(endpoint, status_msg):
 def put_file_add(endpoint, file_info):
     requests.put(endpoint + "/files", json={
         "timestamp": datetime.datetime.now().isoformat(),
-        "file_path": file_info['file_path']
+        "file_path": file_info['file_path'],
+        'adler32': file_info['adler32'],
+        'file_size': file_info['file_size'],
+        'file_events': file_info['file_events']
     })
 
 


### PR DESCRIPTION
# Problem
Need to send logging messages to elastic search

This is partial fulfillment of [Service X Issue #37](https://github.com/ssl-hep/ServiceX/issues/37)

# Approach
Needed to know the total number of bytes and total events in the dataset. Updated the message sent back to the app

