### PR TITLE
Clean up some xAOD assumptions to allow for flat root files

### DIFF
--- a/did_finder/rucio_ops.py
+++ b/did_finder/rucio_ops.py
@@ -34,6 +34,7 @@ def parse_did(did):
     :return: Dictionary with keys "scope" and "name"
     """
     d = dict()
+    print("--->",did)
     d['scope'], d['name'] = did.split(":")
     return d
 
@@ -95,8 +96,11 @@ class DIDSummary:
             self.files_skipped))
 
     def accumulate(self, file_record):
-        self.total_bytes += file_record['file_size']
-        self.total_events += file_record['file_events']
+        file_size_key = 'file_size' if 'file_size' in file_record else 'bytes'
+        file_events_key = 'file_events' if 'file_events' in file_record else 'events'
+
+        self.total_bytes += int(file_record[file_size_key] or 0)
+        self.total_events += int(file_record[file_events_key] or 0)
 
     def add_file(self, file_record):
         self.files += 1

--- a/scripts/did_finder.py
+++ b/scripts/did_finder.py
@@ -97,7 +97,7 @@ def process_did_list(dids, site, did_client, replica_client):
 
                 if sel_path:
                     data = {
-                        'req_id': request_id,
+                        'req_id': "sample-request",
                         'adler32': file['adler32'],
                         'file_size': file['bytes'],
                         'file_events': file['events'],


### PR DESCRIPTION
The rucio results for xAod files all have certain fields populated. When we started working with files generated by a group for their analysis we found a couple of differences. This PR adds extra checks to deal with those cleanly