### PR TITLE
Add fatal error report for zero files in dataset or missing dataset

### DIFF
--- a/src/servicex/did_finder/rucio_adapter.py
+++ b/src/servicex/did_finder/rucio_adapter.py
@@ -26,6 +26,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from rucio.common.exception import DataIdentifierNotFound
 
 
 class RucioAdapter:
@@ -50,8 +51,13 @@ class RucioAdapter:
 
     def list_files_for_did(self, did):
         parsed_did = self.parse_did(did)
-        g_files = self.did_client.list_files(parsed_did['scope'], parsed_did['name'])
-        return g_files
+
+        try:
+            g_files = self.did_client.list_files(parsed_did['scope'], parsed_did['name'])
+            return g_files
+        except DataIdentifierNotFound:
+            print(f"-----> {did} not found")
+            return None
 
     def find_replicas(self, files, site):
         g_replicas = None

--- a/src/servicex/did_finder/servicex_adapter.py
+++ b/src/servicex/did_finder/servicex_adapter.py
@@ -36,14 +36,16 @@ class ServiceXAdapter:
     def __init__(self, endpoint):
         self.endpoint = endpoint
 
-    def post_status_update(self, status_msg):
+    def post_status_update(self, status_msg, severity="info"):
         success = False
         attempts = 0
         while not success and attempts < MAX_RETRIES:
             try:
                 requests.post(self.endpoint + "/status", data={
                     "timestamp": datetime.now().isoformat(),
-                    "status": status_msg
+                    "source": "DID Finder",
+                    "severity": severity,
+                    "info": status_msg
                 })
                 success = True
             except requests.exceptions.ConnectionError:


### PR DESCRIPTION
# Problem
If the DID finder fails to locate a valid dataset, it quietly posts a status message to the app which is not reported to the user.

This is partial solution to (ServiceX Issue 153](https://github.com/ssl-hep/ServiceX/issues/153)

# Approach
After adding a `severity` property to the status POST endpoint, we now check for:
1.  A `DataIdentifierNotFound` exception from the Rucio client
2. An empty list of files from Rucio

We generate a status update for the app where the severity level is set to `fatal`
