### PR TITLE
Stick with root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,15 +37,15 @@ RUN pip install -r requirements.txt
 
 COPY scl_enable /usr/bin/scl_enable
 
-ENV BASH_ENV="/usr/bin/scl_enable" \
-    ENV="/usr/bin/scl_enable" \
-    PROMPT_COMMAND=". /usr/bin/scl_enable"
 
 COPY . .
 
 # build  
 RUN echo "Timestamp:" `date --utc` | tee /image-build-info.txt
-USER user
+
+ENV BASH_ENV="/usr/bin/scl_enable" \
+    ENV="/usr/bin/scl_enable" \
+    PROMPT_COMMAND=". /usr/bin/scl_enable"
 
 ENV X509_USER_PROXY /etc/grid-security/x509up
 


### PR DESCRIPTION
Turns out the DID finder depends on the docker container running as root to populate /etc/grid-security... not good, but will fix later - reported as [ServiceX Issue 203](https://github.com/ssl-hep/ServiceX/issues/203)