### PR TITLE
move to OSG 3.5 and removal of manual python36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rucio/rucio-clients:release-1.23.7.post1
+FROM rucio/rucio-clients:latest
 
 LABEL maintainer Ilija Vukotic <ivukotic@cern.ch>
 
@@ -10,7 +10,8 @@ USER root
 RUN mkdir -p /etc/grid-security/certificates /etc/grid-security/vomsdir 
 
 RUN yum -y update
-RUN yum localinstall https://repo.opensciencegrid.org/osg/3.4/osg-3.4-el7-release-latest.rpm -y
+
+RUN yum install -y https://repo.opensciencegrid.org/osg/3.5/osg-3.5-el7-release-latest.rpm
 
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; \
     curl -s -o /etc/pki/rpm-gpg/RPM-GPG-KEY-wlcg http://linuxsoft.cern.ch/wlcg/RPM-GPG-KEY-wlcg; \
@@ -18,34 +19,18 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 
 RUN yum install osg-ca-certs voms voms-clients wlcg-voms-atlas fetch-crl -y
 
-# We need python3 which is not part of the Rucio docker image
-RUN yum install -y centos-release-scl && \
-     yum install -y rh-python36
-
 # Okay, change our shell to specifically use our software collections.
 # (default was SHELL [ "/bin/sh", "-c" ])
 # https://docs.docker.com/engine/reference/builder/#shell
-#
-# See also `scl` man page for enabling multiple packages if desired:
-# https://linux.die.net/man/1/scl
-SHELL [ "/usr/bin/scl", "enable", "rh-python36" ]
 
 COPY requirements.txt requirements.txt
 
-RUN pip install -r requirements.txt
-
-
-COPY scl_enable /usr/bin/scl_enable
-
+RUN python3 -m pip install -r requirements.txt
 
 COPY . .
 
 # build  
 RUN echo "Timestamp:" `date --utc` | tee /image-build-info.txt
-
-ENV BASH_ENV="/usr/bin/scl_enable" \
-    ENV="/usr/bin/scl_enable" \
-    PROMPT_COMMAND=". /usr/bin/scl_enable"
 
 ENV X509_USER_PROXY /etc/grid-security/x509up
 

--- a/bashrc
+++ b/bashrc
@@ -14,7 +14,4 @@ echo "Enable shell completion on the rucio commands"
 eval "$(register-python-argcomplete rucio)"
 eval "$(register-python-argcomplete rucio-admin)"
 
-# Added by Ben Galewsky for python3 migration
-. /opt/rh/rh-python36/enable
-
 export PYTHONPATH=/usr/src/app/did_finder

--- a/configure_python3.sh
+++ b/configure_python3.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-# Script to initialize the python3 environment inside the docker image
-pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-rucio-clients==1.21.12
+rucio-clients>=1.21.12
 pika==1.1.0
 

--- a/scl_enable
+++ b/scl_enable
@@ -1,3 +1,0 @@
-unset BASH_ENV PROMPT_COMMAND ENV
-source scl_source enable rh-python36
-


### PR DESCRIPTION
the same kind of change as for x509. just a simplification. To work, needs a change in the Chart template too (instead of python call using python3).