### PR TITLE
Make this the Rucio DID Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ServiceX-DID-finder
+# Rucio ServiceX-DID-finder
 ![CI/CD](https://github.com/ssl-hep/ServiceX-DID-finder/workflows/CI/CD/badge.svg)
 [![codecov](https://codecov.io/gh/ssl-hep/ServiceX-DID-finder/branch/master/graph/badge.svg)](https://codecov.io/gh/ssl-hep/ServiceX-DID-finder)
 
@@ -7,7 +7,7 @@ For a given RUCIO DID and client site finds optimal access paths.
 ## Overview
 This service is intended to run as part of a [ServiceX](https://github.com/ssl-hep/ServiceX)
 deployment. In that role it listens for Dataset Lookup requests on the 
-`did_requests` RabbitMQ queue. Upon receipt, it asks Rucio to resolve the
+`rucio_did_requests` RabbitMQ queue. Upon receipt, it asks Rucio to resolve the
 dataset and return the files that make it up. These files are bundled up into
 1,000 file chunks and sent to Rucio's replica client to find available copies 
 on the grid. As these responses come back, the server selects a replica and

--- a/scripts/did_finder.py
+++ b/scripts/did_finder.py
@@ -40,6 +40,7 @@ from servicex.did_finder.lookup_request import LookupRequest
 from servicex.did_finder.rucio_adapter import RucioAdapter
 from servicex.did_finder.servicex_adapter import ServiceXAdapter
 
+QUEUE_NAME = 'rucio_did_requests'
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--site', dest='site', action='store',
@@ -99,11 +100,11 @@ def init_rabbit_mq(rabbitmq_url, retries, retry_interval):
         try:
             rabbitmq = pika.BlockingConnection(pika.URLParameters(rabbitmq_url))
             _channel = rabbitmq.channel()
-            _channel.queue_declare(queue='did_requests')
+            _channel.queue_declare(queue=QUEUE_NAME)
 
             print("Connected to RabbitMQ. Ready to start consuming requests")
 
-            _channel.basic_consume(queue='did_requests',
+            _channel.basic_consume(queue=QUEUE_NAME,
                                    auto_ack=False,
                                    on_message_callback=callback)
             _channel.start_consuming()


### PR DESCRIPTION
# Problem
The service only allows for a single DID finder implementation.

This is partial solution to [ServiceX Isssue #273](https://github.com/ssl-hep/ServiceX/issues/273)

Related PRs:
* [Helm Chart](https://github.com/ssl-hep/ServiceX/pull/280)
* [App](https://github.com/ssl-hep/ServiceX_App/pull/88)

# Approach
In this PR change the name of the queue this service listens on to `rucio_did_requests`.
