### PR TITLE
Remove hard-coded location for X509_USER_PROXY

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The latest image is also available on [dockerhub](https://cloud.docker.com/u/ssl
 The service requires two volumes to be mounted in order to operate:
 1. A valid x509 proxy certificate in `/etc/grid-security-ro`. 
 There is a script that usually gets run to copy the cert to a correctly permissioned
-directory.
+directory. The location of the cert can be overridden by setting the X509_USER_PROXY
+environment variable.
 2. Rucio config file in `/opt/rucio/etc/`
 
 ## Command Line Arguments

--- a/proxy-exporter.sh
+++ b/proxy-exporter.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
-mkdir -p /etc/grid-security
 
+proxydir=$(dirname ${X509_USER_PROXY})
+
+if [[ ! -d $proxydir ]]
+then
+    mkdir -p $proxydir
+fi
 
 while true; do
 
     date
 
     while true; do 
-        cp /etc/grid-security-ro/x509up /etc/grid-security
+        cp /etc/grid-security-ro/x509up ${X509_USER_PROXY}
         RESULT=$?
         if [ $RESULT -eq 0 ]; then
             echo "Got proxy."
-            chmod 600 /etc/grid-security/x509up
+            chmod 600 ${X509_USER_PROXY}
             break 
         else
             echo "Warning: An issue encountered when getting proxy."

--- a/runme.sh
+++ b/runme.sh
@@ -5,7 +5,7 @@
 
 while true; do 
     date
-    ls /etc/grid-security/x509up
+    ls ${X509_USER_PROXY}
     RESULT=$?
     if [ $RESULT -eq 0 ]; then
         echo "Got proxy."


### PR DESCRIPTION
More changes to allow containers to run as unprivileged users rather than root. 