### PR TITLE
Fix code coverage action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,6 @@ jobs:
       with:
         file: ./coverage.xml # optional
         flags: unittests # optional
-        verbose: true
 
   publish:
     needs: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
         pytest --cov=./tests --cov-report=xml
     - name: Report coverage using codecov
       if: github.event_name == 'push' && matrix.python-version == 3.8
-      uses: codecov/codecov-action
+      uses: codecov/codecov-action@v1
       with:
         file: ./coverage.xml # optional
         flags: unittests # optional

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
       run: |
         pip install pytest-cov
         export PYTHONPATH=./src:$PYTHONPATH
-        pytest --cov=./tests --cov-report=xml
+        pytest --cov=./src --cov-report=xml
     - name: Report coverage using codecov
       if: github.event_name == 'push' && matrix.python-version == 3.8
       uses: codecov/codecov-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,10 +33,12 @@ jobs:
     - name: Test with pytest
       run: |
         PYTHONPATH=./src:$PYTHONPATH coverage run -m pytest -r sx
-    - name: Report coverage with Codecov
-      if: github.event_name == 'push'
-      run: |
-        codecov --token=${{ secrets.CODECOV_TOKEN }}
+    - name: Report coverage using codecov
+      if: github.event_name == 'push' && matrix.python-version == 3.8
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml # optional
+        flags: unittests # optional
 
   publish:
     needs: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,8 +32,9 @@ jobs:
         flake8
     - name: Test with pytest
       run: |
-        PYTHONPATH=./src:$PYTHONPATH coverage run -m pytest -r servicex
-        coverage xml
+        pip install pytest-cov
+        export PYTHONPATH=./src:$PYTHONPATH
+        pytest --cov=./tests --cov-report=xml
     - name: Report coverage using codecov
       if: github.event_name == 'push' && matrix.python-version == 3.8
       uses: codecov/codecov-action

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
       with:
         file: ./coverage.xml # optional
         flags: unittests # optional
+        verbose: true
 
   publish:
     needs: test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,11 +32,11 @@ jobs:
         flake8
     - name: Test with pytest
       run: |
-        PYTHONPATH=./src:$PYTHONPATH coverage run -m pytest -r sx
+        PYTHONPATH=./src:$PYTHONPATH coverage run -m pytest -r servicex
         coverage xml
     - name: Report coverage using codecov
       if: github.event_name == 'push' && matrix.python-version == 3.8
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action
       with:
         file: ./coverage.xml # optional
         flags: unittests # optional

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
     - name: Test with pytest
       run: |
         PYTHONPATH=./src:$PYTHONPATH coverage run -m pytest -r sx
+        coverage xml
     - name: Report coverage using codecov
       if: github.event_name == 'push' && matrix.python-version == 3.8
       uses: codecov/codecov-action@v1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rucio ServiceX-DID-finder
 
 ![CI/CD](https://github.com/ssl-hep/ServiceX-DID-finder/workflows/CI/CD/badge.svg)
-[![codecov](https://codecov.io/gh/ssl-hep/ServiceX-DID-finder/branch/master/graph/badge.svg)](https://codecov.io/gh/ssl-hep/ServiceX-DID-finder)
+[![codecov](https://codecov.io/gh/ssl-hep/ServiceX_DID_Finder_Rucio/branch/master/graph/badge.svg?token=xLpoqlrdE3)](https://codecov.io/gh/ssl-hep/ServiceX_DID_Finder_Rucio)
 
 For a given RUCIO DID and client site finds optimal access paths.
 


### PR DESCRIPTION
Fixing up code coverage was done as a seperate PR because it turns out codecoverage was in the original repo, it has just been broken since March of 2020!

* Moved to more modern calling of code coverage (use the pytest plug-in)
* Use github action to push code coverage report
* Minor config fix: making sure install works correctly under WSL