### PR TITLE
Restore 1 hour refresh of proxy

### DIFF
--- a/proxy-exporter.sh
+++ b/proxy-exporter.sh
@@ -22,7 +22,7 @@ while true; do
         fi
     done
 
-    # Refresh every 10 hours
-    sleep 36000
+   # Refresh every hour
+   sleep 3600
 
 done


### PR DESCRIPTION
# Problem
The DID Finder fails after running for several hours with error:
```
2021-09-13 14:10:36,209	ERROR	ConnectionError: HTTPSConnectionPool(host='voatlasrucio-auth-prod.cern.ch', port=443): Max retries exceeded with url: /auth/x509_proxy (Caused by SSLError(SSLError(1, '[SSL: SSLV3_ALERT_CERTIFICATE_EXPIRED] sslv3 alert certificate expired (_ssl.c:877)'),))
```
Fixes #37 

# Approach
Reverted PR #30 and returned to refreshing the proxy every hour