### PR TITLE
Rucio DID Finder Uses --prefix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rucio-clients>=1.26.1
 pika==1.1.0
-servicex-did-finder-lib
+servicex-did-finder-lib>=1.0.1
 xmltodict
 wheel

--- a/runme.sh
+++ b/runme.sh
@@ -13,6 +13,8 @@ while true; do
     sleep 5
 done
 
+if [ -z $CACHE_PREFIX ]; then export PREFIX_ARG=""; else export PREFIX_ARG="--prefix $CACHE_PREFIX"; fi
+
 export PYTHONPATH=./src
-python3 scripts/did_finder.py --rabbit-uri $RMQ_URI
+python3 scripts/did_finder.py --rabbit-uri $RMQ_URI $PREFIX_ARG
 

--- a/scripts/did_finder.py
+++ b/scripts/did_finder.py
@@ -43,9 +43,6 @@ def run_rucio_finder():
 
     # Parse the command line arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument('--prefix', dest='prefix', action='store',
-                        default='',
-                        help='Prefix to add to Xrootd URLs')
     add_did_finder_cnd_arguments(parser)
 
     args = parser.parse_args()


### PR DESCRIPTION
# Problem
The Rucio DID Finder needs to make use of the --prefix command line argument in the DIDFinder Lib.

Partial solution to [ServiceX Issue 318](https://github.com/ssl-hep/ServiceX/issues/318)

# Approach
Remove the custom --prefix argument that had been added to the Rucio DID Finder since it is now in the library

If the DID Finder pod is launched with the environment var CACHE_PREFIX pass that to the DID Finder script