### PR TITLE
Move X509_USER_PROXY to /tmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,5 @@ COPY . .
 # build  
 RUN echo "Timestamp:" `date --utc` | tee /image-build-info.txt
 
-ENV X509_USER_PROXY /etc/grid-security/x509up
+ENV X509_USER_PROXY /tmp/grid-security/x509up
 ENV X509_CERT_DIR /etc/grid-security/certificates


### PR DESCRIPTION
# Problem
OpenShift deployments can't write copies of the user proxy to /etc

Partial solution to [ServiceX Issue 364](https://github.com/ssl-hep/ServiceX/issues/364)

# Approach
Changed the X509_USER_PROXY to /tmp/grid-security/x509up