### PR TITLE
Add report-logical-files option to find logical files instead of replicas

### DIFF
--- a/runme.sh
+++ b/runme.sh
@@ -14,7 +14,8 @@ while true; do
 done
 
 if [ -z $CACHE_PREFIX ]; then export PREFIX_ARG=""; else export PREFIX_ARG="--prefix $CACHE_PREFIX"; fi
-
 export PYTHONPATH=./src
-python3 scripts/did_finder.py --rabbit-uri $RMQ_URI $PREFIX_ARG
+
+# Assume $REPORT_LOGICAL_FILES is set to --report-logical-files to activate
+python3 scripts/did_finder.py --rabbit-uri $RMQ_URI $PREFIX_ARG $REPORT_LOGICAL_FILES
 

--- a/scripts/did_finder.py
+++ b/scripts/did_finder.py
@@ -43,6 +43,7 @@ def run_rucio_finder():
 
     # Parse the command line arguments
     parser = argparse.ArgumentParser()
+    parser.add_argument("--report-logical-files", action="store_true")
     add_did_finder_cnd_arguments(parser)
 
     args = parser.parse_args()
@@ -52,10 +53,13 @@ def run_rucio_finder():
     logger.info("ServiceX DID Finder starting up. "
                 f"Prefix: {prefix}")
 
+    if args.report_logical_files:
+        logger.info("---- DID Finder Only Returning Logical Names, not replicas -----")
+
     # Initialize the finder
     did_client = DIDClient()
     replica_client = ReplicaClient()
-    rucio_adapter = RucioAdapter(did_client, replica_client)
+    rucio_adapter = RucioAdapter(did_client, replica_client, args.report_logical_files)
 
     # Run the DID Finder
     try:

--- a/src/servicex/did_finder/rucio_adapter.py
+++ b/src/servicex/did_finder/rucio_adapter.py
@@ -32,9 +32,10 @@ from rucio.common.exception import DataIdentifierNotFound
 
 
 class RucioAdapter:
-    def __init__(self, did_client, replica_client):
+    def __init__(self, did_client, replica_client, report_logical_files=False):
         self.did_client = did_client
         self.replica_client = replica_client
+        self.report_logical_files = report_logical_files
 
         # set logging to a null handler
         self.logger = logging.getLogger(__name__)
@@ -122,12 +123,17 @@ class RucioAdapter:
                 else:
                     mfile = d['metalink']['file']
                 for f in mfile:
+                    # Path is either a list of replicas or a single logical name
+                    path = self.get_paths(f['url']) \
+                        if not self.report_logical_files else \
+                        [f['identity']]
+
                     g_files.append(
                         {
                             'adler32': self.get_adler(f['hash']),
                             'file_size': int(f['size'], 10),
                             'file_events': 0,
-                            'file_path': self.get_paths(f['url'])
+                            'file_path': path
                         }
                     )
             yield g_files


### PR DESCRIPTION
# Problem
The CMS deployment of xCache assumes that the URIs for Root files is the logical name (not a replica URL)

Partial solution to [ServiceX issue 369](https://github.com/ssl-hep/ServiceX/issues/369)

# Approach
Added a new command line argument: `--report-logical-files` 
If this is set, then the RucioAdaptor returns the `identity` property instead of the `url`