### PR TITLE
Pick up version of did-finder library that drops the preflight

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rucio-clients>=1.26.1
 pika==1.1.0
-servicex-did-finder-lib>=1.0.1
+servicex-did-finder-lib>=1.0.2
 xmltodict
 wheel


### PR DESCRIPTION
Partial solution to [ServiceX Issue 378] (https://github.com/ssl-hep/ServiceX/pull/378)