### PR TITLE
Enable parsing of DID parameters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rucio-clients>=1.26.1
 pika==1.1.0
-servicex-did-finder-lib>=1.0.2
+servicex-did-finder-lib>=1.1b1
 xmltodict
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rucio-clients>=1.26.1
 pika==1.1.0
-servicex-did-finder-lib>=1.1a3
+servicex-did-finder-lib>=1.1a4
 xmltodict
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rucio-clients>=1.26.1
 pika==1.1.0
-servicex-did-finder-lib>=1.1a2
+servicex-did-finder-lib>=1.1a3
 xmltodict
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rucio-clients>=1.26.1
 pika==1.1.0
-servicex-did-finder-lib>=1.1a1
+servicex-did-finder-lib>=1.1ab
 xmltodict
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rucio-clients>=1.26.1
 pika==1.1.0
-servicex-did-finder-lib>=1.1ab
+servicex-did-finder-lib>=1.1a2
 xmltodict
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rucio-clients>=1.26.1
 pika==1.1.0
-servicex-did-finder-lib==1.1b2
+servicex-did-finder-lib>=1.1
 xmltodict
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rucio-clients>=1.26.1
 pika==1.1.0
-servicex-did-finder-lib>=1.1a5
+servicex-did-finder-lib>=1.1b1
 xmltodict
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rucio-clients>=1.26.1
 pika==1.1.0
-servicex-did-finder-lib>=1.1b1
+servicex-did-finder-lib>=1.1a1
 xmltodict
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 rucio-clients>=1.26.1
 pika==1.1.0
-servicex-did-finder-lib>=1.1b1
+servicex-did-finder-lib==1.1b2
 xmltodict
 wheel

--- a/src/servicex/did_finder/rucio_adapter.py
+++ b/src/servicex/did_finder/rucio_adapter.py
@@ -120,6 +120,7 @@ class RucioAdapter:
         datasets = self.list_datasets_for_did(did)
         if not datasets:
             return
+        no_replica_files = 0
         for ds in datasets:
             reps = self.replica_client.list_replicas(
                 [{'scope': ds[0], 'name': ds[1]}],
@@ -140,6 +141,7 @@ class RucioAdapter:
                     # Path is either a list of replicas or a single logical name
                     if 'url' not in f:
                         self.logger.error(f"File {f['identity']} has no replicas.")
+                        no_replica_files += 1
                         continue
                     path = self.get_paths(f['url']) \
                         if not self.report_logical_files else \
@@ -154,3 +156,6 @@ class RucioAdapter:
                         }
                     )
             yield g_files
+
+        if no_replica_files > 0:
+            raise ValueError(f'Dataset {did} is missing replicas for {no_replica_files} of its files.')

--- a/src/servicex/did_finder/rucio_adapter.py
+++ b/src/servicex/did_finder/rucio_adapter.py
@@ -158,4 +158,5 @@ class RucioAdapter:
             yield g_files
 
         if no_replica_files > 0:
-            raise ValueError(f'Dataset {did} is missing replicas for {no_replica_files} of its files.')
+            raise ValueError(f'Dataset {did} is missing replicas for {no_replica_files} '
+                             'of its files.')


### PR DESCRIPTION
* New version of DID library that parses `get` and `files` parameters
* Reshape replica-not-found errors so that they are reported via an exception at the very end.

See the [ServiceX story](https://github.com/ssl-hep/ServiceX/issues/395) for more background information.